### PR TITLE
misc minor cleanup to prep for code-import in https://bugzilla.mozilla.org/show_bug.cgi?id=1132748

### DIFF
--- a/cssfixme.htm
+++ b/cssfixme.htm
@@ -263,7 +263,6 @@ function createFixupGradientDeclaration(decl, parent){
             stops = [];
             if(/^linear/.test(type)){
                 // linear gradient, args 1 and 2 tend to be start/end keywords
-                console.log(value);
                 points = [].concat(parts[i].args[1].name.split(/\s+/), parts[i].args[2].name.split(/\s+/)); // example: [left, top, right, top]
                 // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
                 // if start/end keywords are percentages, let's massage the values a little more..
@@ -367,7 +366,7 @@ function createFixupGradientDeclaration(decl, parent){
     if(head){
         newValue = head + newValue;
     }
-    GM_log(newValue)
+    // GM_log(newValue)
     return {type:'declaration', property:prop, value:newValue, _fxjsdefined:true};
 }
 

--- a/cssfixme.htm
+++ b/cssfixme.htm
@@ -249,7 +249,7 @@ function createFixupGradientDeclaration(decl, parent){
     if(head){
         value = value.substr(head.length);
     }
-    var m = value.match(/-webkit-gradient\s*\(\s*(linear|radial)\s*(.*)/), points=[], toColor, stops=[];
+    var m = value.match(/-webkit-gradient\s*\(\s*(linear|radial)\s*(.*)/);
     if(m){ // yay, really old syntax...
 
         // extracting the values..
@@ -260,10 +260,10 @@ function createFixupGradientDeclaration(decl, parent){
                 type = parts[i].args[0].name;
                 newValue += type + '-gradient('; // radial or linear
             }
-            stops = [];
+            var stops = [];
             if(/^linear/.test(type)){
                 // linear gradient, args 1 and 2 tend to be start/end keywords
-                points = [].concat(parts[i].args[1].name.split(/\s+/), parts[i].args[2].name.split(/\s+/)); // example: [left, top, right, top]
+                var points = [].concat(parts[i].args[1].name.split(/\s+/), parts[i].args[2].name.split(/\s+/)); // example: [left, top, right, top]
                 // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
                 // if start/end keywords are percentages, let's massage the values a little more..
                 var rxPercTest = /\d+\%/;
@@ -286,6 +286,7 @@ function createFixupGradientDeclaration(decl, parent){
                 newValue += 'circle ' + parts[i].args[4].name.replace(/(\d+)$/, '$1px') + ' at ' + parts[i].args[1].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
             }
 
+            var toColor;
             for(var j = type === 'linear' ? 3 : 5; j < parts[i].args.length; j++){
                 var position, color, colorIndex;
                 if(parts[i].args[j].name === 'color-stop'){


### PR DESCRIPTION
There are various calls to GM_log which are commented out (presumably for debugging), but there's one straggler. This patch comments that call out, for consistency & code-reusability.

Also, I'm removing a stray "console.log(value)" (the only such line), for the same reasons.
