### PR TITLE
Refactor code for standardizing old gradient args

### DIFF
--- a/cssfixme.htm
+++ b/cssfixme.htm
@@ -273,70 +273,70 @@ function createFixupGradientDeclaration(decl, parent){
  *              provided by oldGradientParser() (not including gradient type).
  */
 function standardizeOldGradientArgs(type, args){
-            var stdArgStr = "";
-            var stops = [];
-            if(/^linear/.test(type)){
-                // linear gradient, args 1 and 2 tend to be start/end keywords
-                var points = [].concat(args[0].name.split(/\s+/), args[1].name.split(/\s+/)); // example: [left, top, right, top]
-                // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
-                // if start/end keywords are percentages, let's massage the values a little more..
-                var rxPercTest = /\d+\%/;
-                if(rxPercTest.test(points[0]) || points[0] == 0){
-                    var startX = parseInt(points[0]), startY = parseInt(points[1]), endX = parseInt(points[2]), endY = parseInt(points[3]);
-                    stdArgStr +=  ((Math.atan2(endY- startY, endX - startX)) * (180 / Math.PI)+90) + 'deg';
-                }else{
-                    if(points[1] === points[3]){ // both 'top' or 'bottom, this linear gradient goes left-right
-                        stdArgStr += 'to ' + points[2];
-                    }else if(points[0] === points[2]){ // both 'left' or 'right', this linear gradient goes top-bottom
-                        stdArgStr += 'to ' + points[3];
-                    }else if(points[1] === 'top'){ // diagonal gradient - from top left to opposite corner is 135deg
-                        stdArgStr += '135deg';
-                    }else{
-                        stdArgStr += '45deg';
-                    }
-                }
+    var stdArgStr = "";
+    var stops = [];
+    if(/^linear/.test(type)){
+        // linear gradient, args 1 and 2 tend to be start/end keywords
+        var points = [].concat(args[0].name.split(/\s+/), args[1].name.split(/\s+/)); // example: [left, top, right, top]
+        // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
+        // if start/end keywords are percentages, let's massage the values a little more..
+        var rxPercTest = /\d+\%/;
+        if(rxPercTest.test(points[0]) || points[0] == 0){
+            var startX = parseInt(points[0]), startY = parseInt(points[1]), endX = parseInt(points[2]), endY = parseInt(points[3]);
+            stdArgStr +=  ((Math.atan2(endY- startY, endX - startX)) * (180 / Math.PI)+90) + 'deg';
+        }else{
+            if(points[1] === points[3]){ // both 'top' or 'bottom, this linear gradient goes left-right
+                stdArgStr += 'to ' + points[2];
+            }else if(points[0] === points[2]){ // both 'left' or 'right', this linear gradient goes top-bottom
+                stdArgStr += 'to ' + points[3];
+            }else if(points[1] === 'top'){ // diagonal gradient - from top left to opposite corner is 135deg
+                stdArgStr += '135deg';
+            }else{
+                stdArgStr += '45deg';
+            }
+        }
 
-            }else if(/^radial/i.test(type)){ // oooh, radial gradients..
-                stdArgStr += 'circle ' + args[3].name.replace(/(\d+)$/, '$1px') + ' at ' + args[0].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
-            }
+    }else if(/^radial/i.test(type)){ // oooh, radial gradients..
+        stdArgStr += 'circle ' + args[3].name.replace(/(\d+)$/, '$1px') + ' at ' + args[0].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
+    }
 
-            var toColor;
-            for(var j = type === 'linear' ? 2 : 4; j < args.length; j++){
-                var position, color, colorIndex;
-                if(args[j].name === 'color-stop'){
-                    position = args[j].args[0].name;
-                    colorIndex = 1;
-                }else if (args[j].name === 'to') {
-                    position = '100%';
-                    colorIndex = 0;
-                }else if (args[j].name === 'from') {
-                    position = '0%';
-                    colorIndex = 0;
-                };
-                if (position.indexOf('%') === -1) { // original Safari syntax had 0.5 equivalent to 50%
-                    position = (parseFloat(position) * 100) +'%';
-                };
-                color = args[j].args[colorIndex].name;
-                if (args[j].args[colorIndex].args) { // the color is itself a function call, like rgb()
-                    color += '(' + colorValue(args[j].args[colorIndex].args) + ')';
-                };
-                if (args[j].name === 'from'){
-                    stops.unshift(color + ' ' + position);
-                }else if(args[j].name === 'to'){
-                    toColor = color;
-                }else{
-                    stops.push(color + ' ' + position);
-                }
-            }
+    var toColor;
+    for(var j = type === 'linear' ? 2 : 4; j < args.length; j++){
+        var position, color, colorIndex;
+        if(args[j].name === 'color-stop'){
+            position = args[j].args[0].name;
+            colorIndex = 1;
+        }else if (args[j].name === 'to') {
+            position = '100%';
+            colorIndex = 0;
+        }else if (args[j].name === 'from') {
+            position = '0%';
+            colorIndex = 0;
+        };
+        if (position.indexOf('%') === -1) { // original Safari syntax had 0.5 equivalent to 50%
+            position = (parseFloat(position) * 100) +'%';
+        };
+        color = args[j].args[colorIndex].name;
+        if (args[j].args[colorIndex].args) { // the color is itself a function call, like rgb()
+            color += '(' + colorValue(args[j].args[colorIndex].args) + ')';
+        };
+        if (args[j].name === 'from'){
+            stops.unshift(color + ' ' + position);
+        }else if(args[j].name === 'to'){
+            toColor = color;
+        }else{
+            stops.push(color + ' ' + position);
+        }
+    }
 
-            // translating values to right syntax
-            for(var j = 0; j < stops.length; j++){
-                stdArgStr += ', ' + stops[j];
-            }
-            if(toColor){
-                stdArgStr += ', ' + toColor + ' 100%';
-            }
-            return stdArgStr;
+    // translating values to right syntax
+    for(var j = 0; j < stops.length; j++){
+        stdArgStr += ', ' + stops[j];
+    }
+    if(toColor){
+        stdArgStr += ', ' + toColor + ' 100%';
+    }
+    return stdArgStr;
 }
 // XXXdholbert END NEW FUNCTION. (Now we invoke it:)
             newValue += standardizeOldGradientArgs(type, parts[i].args.slice(1));

--- a/cssfixme.htm
+++ b/cssfixme.htm
@@ -260,55 +260,69 @@ function createFixupGradientDeclaration(decl, parent){
                 type = parts[i].args[0].name;
                 newValue += type + '-gradient('; // radial or linear
             }
+// XXXdholbert BEGIN NEW FUNCTION.
+// This will be moved outside of createFixupGradientDeclaration; I'm leaving
+// it inside temporarily to make it clearer what's actually changing.
+/* Given an array of args for "-webkit-gradient(...)" returned by
+ * oldGradientParser(), this function constructs a string representing the
+ * equivalent arguments for a standard "linear-gradient(...)" or
+ * "radial-gradient(...)" expression.
+ *
+ * @param type  Either 'linear' or 'radial'.
+ * @param args  An array of args for a "-webkit-gradient(...)" expression,
+ *              provided by oldGradientParser().
+ */
+function standardizeOldGradientArgs(type, args){
+            var stdArgStr = "";
             var stops = [];
             if(/^linear/.test(type)){
                 // linear gradient, args 1 and 2 tend to be start/end keywords
-                var points = [].concat(parts[i].args[1].name.split(/\s+/), parts[i].args[2].name.split(/\s+/)); // example: [left, top, right, top]
+                var points = [].concat(args[1].name.split(/\s+/), args[2].name.split(/\s+/)); // example: [left, top, right, top]
                 // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
                 // if start/end keywords are percentages, let's massage the values a little more..
                 var rxPercTest = /\d+\%/;
                 if(rxPercTest.test(points[0]) || points[0] == 0){
                     var startX = parseInt(points[0]), startY = parseInt(points[1]), endX = parseInt(points[2]), endY = parseInt(points[3]);
-                    newValue +=  ((Math.atan2(endY- startY, endX - startX)) * (180 / Math.PI)+90) + 'deg';
+                    stdArgStr +=  ((Math.atan2(endY- startY, endX - startX)) * (180 / Math.PI)+90) + 'deg';
                 }else{
                     if(points[1] === points[3]){ // both 'top' or 'bottom, this linear gradient goes left-right
-                        newValue += 'to ' + points[2];
+                        stdArgStr += 'to ' + points[2];
                     }else if(points[0] === points[2]){ // both 'left' or 'right', this linear gradient goes top-bottom
-                        newValue += 'to ' + points[3];
+                        stdArgStr += 'to ' + points[3];
                     }else if(points[1] === 'top'){ // diagonal gradient - from top left to opposite corner is 135deg
-                        newValue += '135deg';
+                        stdArgStr += '135deg';
                     }else{
-                        newValue += '45deg';
+                        stdArgStr += '45deg';
                     }
                 }
 
             }else if(/^radial/i.test(type)){ // oooh, radial gradients..
-                newValue += 'circle ' + parts[i].args[4].name.replace(/(\d+)$/, '$1px') + ' at ' + parts[i].args[1].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
+                stdArgStr += 'circle ' + args[4].name.replace(/(\d+)$/, '$1px') + ' at ' + args[1].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
             }
 
             var toColor;
-            for(var j = type === 'linear' ? 3 : 5; j < parts[i].args.length; j++){
+            for(var j = type === 'linear' ? 3 : 5; j < args.length; j++){
                 var position, color, colorIndex;
-                if(parts[i].args[j].name === 'color-stop'){
-                    position = parts[i].args[j].args[0].name;
+                if(args[j].name === 'color-stop'){
+                    position = args[j].args[0].name;
                     colorIndex = 1;
-                }else if (parts[i].args[j].name === 'to') {
+                }else if (args[j].name === 'to') {
                     position = '100%';
                     colorIndex = 0;
-                }else if (parts[i].args[j].name === 'from') {
+                }else if (args[j].name === 'from') {
                     position = '0%';
                     colorIndex = 0;
                 };
                 if (position.indexOf('%') === -1) { // original Safari syntax had 0.5 equivalent to 50%
                     position = (parseFloat(position) * 100) +'%';
                 };
-                color = parts[i].args[j].args[colorIndex].name;
-                if (parts[i].args[j].args[colorIndex].args) { // the color is itself a function call, like rgb()
-                    color += '(' + colorValue(parts[i].args[j].args[colorIndex].args) + ')';
+                color = args[j].args[colorIndex].name;
+                if (args[j].args[colorIndex].args) { // the color is itself a function call, like rgb()
+                    color += '(' + colorValue(args[j].args[colorIndex].args) + ')';
                 };
-                if (parts[i].args[j].name === 'from'){
+                if (args[j].name === 'from'){
                     stops.unshift(color + ' ' + position);
-                }else if(parts[i].args[j].name === 'to'){
+                }else if(args[j].name === 'to'){
                     toColor = color;
                 }else{
                     stops.push(color + ' ' + position);
@@ -317,11 +331,15 @@ function createFixupGradientDeclaration(decl, parent){
 
             // translating values to right syntax
             for(var j = 0; j < stops.length; j++){
-                newValue += ', ' + stops[j];
+                stdArgStr += ', ' + stops[j];
             }
             if(toColor){
-                newValue += ', ' + toColor + ' 100%';
+                stdArgStr += ', ' + toColor + ' 100%';
             }
+            return stdArgStr;
+}
+// XXXdholbert END NEW FUNCTION. (Now we invoke it:)
+            newValue += standardizeOldGradientArgs(type, parts[i].args);
             newValue += ')' // end of gradient method
             if (i < parts.length - 1) {
                 newValue += ', '

--- a/cssfixme.htm
+++ b/cssfixme.htm
@@ -270,14 +270,14 @@ function createFixupGradientDeclaration(decl, parent){
  *
  * @param type  Either 'linear' or 'radial'.
  * @param args  An array of args for a "-webkit-gradient(...)" expression,
- *              provided by oldGradientParser().
+ *              provided by oldGradientParser() (not including gradient type).
  */
 function standardizeOldGradientArgs(type, args){
             var stdArgStr = "";
             var stops = [];
             if(/^linear/.test(type)){
                 // linear gradient, args 1 and 2 tend to be start/end keywords
-                var points = [].concat(args[1].name.split(/\s+/), args[2].name.split(/\s+/)); // example: [left, top, right, top]
+                var points = [].concat(args[0].name.split(/\s+/), args[1].name.split(/\s+/)); // example: [left, top, right, top]
                 // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
                 // if start/end keywords are percentages, let's massage the values a little more..
                 var rxPercTest = /\d+\%/;
@@ -297,11 +297,11 @@ function standardizeOldGradientArgs(type, args){
                 }
 
             }else if(/^radial/i.test(type)){ // oooh, radial gradients..
-                stdArgStr += 'circle ' + args[4].name.replace(/(\d+)$/, '$1px') + ' at ' + args[1].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
+                stdArgStr += 'circle ' + args[3].name.replace(/(\d+)$/, '$1px') + ' at ' + args[0].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
             }
 
             var toColor;
-            for(var j = type === 'linear' ? 3 : 5; j < args.length; j++){
+            for(var j = type === 'linear' ? 2 : 4; j < args.length; j++){
                 var position, color, colorIndex;
                 if(args[j].name === 'color-stop'){
                     position = args[j].args[0].name;
@@ -339,7 +339,7 @@ function standardizeOldGradientArgs(type, args){
             return stdArgStr;
 }
 // XXXdholbert END NEW FUNCTION. (Now we invoke it:)
-            newValue += standardizeOldGradientArgs(type, parts[i].args);
+            newValue += standardizeOldGradientArgs(type, parts[i].args.slice(1));
             newValue += ')' // end of gradient method
             if (i < parts.length - 1) {
                 newValue += ', '

--- a/cssfixme.htm
+++ b/cssfixme.htm
@@ -260,85 +260,6 @@ function createFixupGradientDeclaration(decl, parent){
                 type = parts[i].args[0].name;
                 newValue += type + '-gradient('; // radial or linear
             }
-// XXXdholbert BEGIN NEW FUNCTION.
-// This will be moved outside of createFixupGradientDeclaration; I'm leaving
-// it inside temporarily to make it clearer what's actually changing.
-/* Given an array of args for "-webkit-gradient(...)" returned by
- * oldGradientParser(), this function constructs a string representing the
- * equivalent arguments for a standard "linear-gradient(...)" or
- * "radial-gradient(...)" expression.
- *
- * @param type  Either 'linear' or 'radial'.
- * @param args  An array of args for a "-webkit-gradient(...)" expression,
- *              provided by oldGradientParser() (not including gradient type).
- */
-function standardizeOldGradientArgs(type, args){
-    var stdArgStr = "";
-    var stops = [];
-    if(/^linear/.test(type)){
-        // linear gradient, args 1 and 2 tend to be start/end keywords
-        var points = [].concat(args[0].name.split(/\s+/), args[1].name.split(/\s+/)); // example: [left, top, right, top]
-        // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
-        // if start/end keywords are percentages, let's massage the values a little more..
-        var rxPercTest = /\d+\%/;
-        if(rxPercTest.test(points[0]) || points[0] == 0){
-            var startX = parseInt(points[0]), startY = parseInt(points[1]), endX = parseInt(points[2]), endY = parseInt(points[3]);
-            stdArgStr +=  ((Math.atan2(endY- startY, endX - startX)) * (180 / Math.PI)+90) + 'deg';
-        }else{
-            if(points[1] === points[3]){ // both 'top' or 'bottom, this linear gradient goes left-right
-                stdArgStr += 'to ' + points[2];
-            }else if(points[0] === points[2]){ // both 'left' or 'right', this linear gradient goes top-bottom
-                stdArgStr += 'to ' + points[3];
-            }else if(points[1] === 'top'){ // diagonal gradient - from top left to opposite corner is 135deg
-                stdArgStr += '135deg';
-            }else{
-                stdArgStr += '45deg';
-            }
-        }
-
-    }else if(/^radial/i.test(type)){ // oooh, radial gradients..
-        stdArgStr += 'circle ' + args[3].name.replace(/(\d+)$/, '$1px') + ' at ' + args[0].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
-    }
-
-    var toColor;
-    for(var j = type === 'linear' ? 2 : 4; j < args.length; j++){
-        var position, color, colorIndex;
-        if(args[j].name === 'color-stop'){
-            position = args[j].args[0].name;
-            colorIndex = 1;
-        }else if (args[j].name === 'to') {
-            position = '100%';
-            colorIndex = 0;
-        }else if (args[j].name === 'from') {
-            position = '0%';
-            colorIndex = 0;
-        };
-        if (position.indexOf('%') === -1) { // original Safari syntax had 0.5 equivalent to 50%
-            position = (parseFloat(position) * 100) +'%';
-        };
-        color = args[j].args[colorIndex].name;
-        if (args[j].args[colorIndex].args) { // the color is itself a function call, like rgb()
-            color += '(' + colorValue(args[j].args[colorIndex].args) + ')';
-        };
-        if (args[j].name === 'from'){
-            stops.unshift(color + ' ' + position);
-        }else if(args[j].name === 'to'){
-            toColor = color;
-        }else{
-            stops.push(color + ' ' + position);
-        }
-    }
-
-    // translating values to right syntax
-    for(var j = 0; j < stops.length; j++){
-        stdArgStr += ', ' + stops[j];
-    }
-    if(toColor){
-        stdArgStr += ', ' + toColor + ' 100%';
-    }
-    return stdArgStr;
-}
-// XXXdholbert END NEW FUNCTION. (Now we invoke it:)
             newValue += standardizeOldGradientArgs(type, parts[i].args.slice(1));
             newValue += ')' // end of gradient method
             if (i < parts.length - 1) {
@@ -449,6 +370,82 @@ function oldGradientParser(str){
     }
 
     return objs;
+}
+
+/* Given an array of args for "-webkit-gradient(...)" returned by
+ * oldGradientParser(), this function constructs a string representing the
+ * equivalent arguments for a standard "linear-gradient(...)" or
+ * "radial-gradient(...)" expression.
+ *
+ * @param type  Either 'linear' or 'radial'.
+ * @param args  An array of args for a "-webkit-gradient(...)" expression,
+ *              provided by oldGradientParser() (not including gradient type).
+ */
+function standardizeOldGradientArgs(type, args){
+    var stdArgStr = "";
+    var stops = [];
+    if(/^linear/.test(type)){
+        // linear gradient, args 1 and 2 tend to be start/end keywords
+        var points = [].concat(args[0].name.split(/\s+/), args[1].name.split(/\s+/)); // example: [left, top, right, top]
+        // Old webkit syntax "uses a two-point syntax that lets you explicitly state where a linear gradient starts and ends"
+        // if start/end keywords are percentages, let's massage the values a little more..
+        var rxPercTest = /\d+\%/;
+        if(rxPercTest.test(points[0]) || points[0] == 0){
+            var startX = parseInt(points[0]), startY = parseInt(points[1]), endX = parseInt(points[2]), endY = parseInt(points[3]);
+            stdArgStr +=  ((Math.atan2(endY- startY, endX - startX)) * (180 / Math.PI)+90) + 'deg';
+        }else{
+            if(points[1] === points[3]){ // both 'top' or 'bottom, this linear gradient goes left-right
+                stdArgStr += 'to ' + points[2];
+            }else if(points[0] === points[2]){ // both 'left' or 'right', this linear gradient goes top-bottom
+                stdArgStr += 'to ' + points[3];
+            }else if(points[1] === 'top'){ // diagonal gradient - from top left to opposite corner is 135deg
+                stdArgStr += '135deg';
+            }else{
+                stdArgStr += '45deg';
+            }
+        }
+
+    }else if(/^radial/i.test(type)){ // oooh, radial gradients..
+        stdArgStr += 'circle ' + args[3].name.replace(/(\d+)$/, '$1px') + ' at ' + args[0].name.replace(/(\d+) /, '$1px ').replace(/(\d+)$/, '$1px');
+    }
+
+    var toColor;
+    for(var j = type === 'linear' ? 2 : 4; j < args.length; j++){
+        var position, color, colorIndex;
+        if(args[j].name === 'color-stop'){
+            position = args[j].args[0].name;
+            colorIndex = 1;
+        }else if (args[j].name === 'to') {
+            position = '100%';
+            colorIndex = 0;
+        }else if (args[j].name === 'from') {
+            position = '0%';
+            colorIndex = 0;
+        };
+        if (position.indexOf('%') === -1) { // original Safari syntax had 0.5 equivalent to 50%
+            position = (parseFloat(position) * 100) +'%';
+        };
+        color = args[j].args[colorIndex].name;
+        if (args[j].args[colorIndex].args) { // the color is itself a function call, like rgb()
+            color += '(' + colorValue(args[j].args[colorIndex].args) + ')';
+        };
+        if (args[j].name === 'from'){
+            stops.unshift(color + ' ' + position);
+        }else if(args[j].name === 'to'){
+            toColor = color;
+        }else{
+            stops.push(color + ' ' + position);
+        }
+    }
+
+    // translating values to right syntax
+    for(var j = 0; j < stops.length; j++){
+        stdArgStr += ', ' + stops[j];
+    }
+    if(toColor){
+        stdArgStr += ', ' + toColor + ' 100%';
+    }
+    return stdArgStr;
 }
 
 function colorValue(obj){


### PR DESCRIPTION
This patch-stack refactors the existing code for standardizing old gradient args into a helper-function.
- The first patch creates the function (inline in the caller for now, to minimize bitrot, so you can see what's being changed). 
- The second patch adjusts the function so that its "args" array no longer expects to have the gradient type (linear/radial) in the 0th slot. (This is needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1132748 )
- The third patch de-indents the function. (whitespace-only)
- The fourth patch moves the function out of its caller, to be a top-level function. (code-move only)
